### PR TITLE
change regex for github hashtag matching

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 
 gem "html-proofer"
+gem 'html-pipeline-hashtag'
 gem "jekyll-paginate"
 gem "jekyll-mentions"
 gem "jekyll-seo-tag"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,6 +17,8 @@ GEM
     html-pipeline (2.6.0)
       activesupport (>= 2)
       nokogiri (>= 1.4)
+    html-pipeline-hashtag (0.1.1)
+      html-pipeline (>= 2.2.1)
     html-proofer (3.7.2)
       activesupport (>= 4.2, < 6.0)
       addressable (~> 2.3)
@@ -82,6 +84,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  html-pipeline-hashtag
   html-proofer
   jekyll-mentions
   jekyll-paginate

--- a/_pages/documentation/walkthrough.md
+++ b/_pages/documentation/walkthrough.md
@@ -30,7 +30,7 @@ int main(void) {
 ```
 
 First we make sure the GPIO pin connected to the LED (which is connected to
-GPIO pin 0) is enabled as an output (line #4). Then, in an infinite loop, we
+GPIO pin 0) is enabled as an output (line 4). Then, in an infinite loop, we
 toggle the LED and wait for 500ms.
 
 Under the hood, the kernel initializes the chip, board and peripherals, protects

--- a/_plugins/github_issues.rb
+++ b/_plugins/github_issues.rb
@@ -1,0 +1,58 @@
+require "jekyll"
+require "html/pipeline"
+require 'html/pipeline/hashtag/hashtag_filter'
+
+module Jekyll
+  class Issues
+    ISSUE_PREFIX_URL = "https://github.com/helena-project/tock/issues/%{tag}".freeze
+    BODY_START_TAG = "<body".freeze
+
+    InvalidJekyllMentionConfig = Class.new(Jekyll::Errors::FatalException)
+
+    class << self
+      def issuify(doc)
+        return unless doc.output.include?("@")
+        src = ISSUE_PREFIX_URL
+        if doc.output.include? BODY_START_TAG
+          parsed_doc    = Nokogiri::HTML::Document.parse(doc.output)
+          body          = parsed_doc.at_css("body")
+          body.children = filter_with_mention(src).call(body.inner_html)[:output].to_s
+          doc.output    = parsed_doc.to_html
+        else
+          doc.output = filter_with_mention(src).call(doc.output)[:output].to_s
+        end
+      end
+
+      # Public: Create or fetch the filter for the given {{src}} base URL.
+      #
+      # src - the base URL (e.g. https://github.com)
+      #
+      # Returns an HTML::Pipeline instance for the given base URL.
+      def filter_with_mention(src)
+        filters[src] ||= HTML::Pipeline.new([
+          HTML::Pipeline::HashtagFilter,
+        ], { :tag_url => src })
+      end
+
+      # Public: Filters hash where the key is the mention base URL.
+      # Effectively a cache.
+      def filters
+        @filters ||= {}
+      end
+
+      # Public: Defines the conditions for a document to be emojiable.
+      #
+      # doc - the Jekyll::Document or Jekyll::Page
+      #
+      # Returns true if the doc is written & is HTML.
+      def issueable?(doc)
+        (doc.is_a?(Jekyll::Page) || doc.write?) &&
+          doc.output_ext == ".html" || (doc.permalink && doc.permalink.end_with?("/"))
+      end
+    end
+  end
+end
+
+Jekyll::Hooks.register %i[pages documents], :post_render do |doc|
+  Jekyll::Issues.issuify(doc) if Jekyll::Issues.issueable?(doc)
+end

--- a/_plugins/github_issues.rb
+++ b/_plugins/github_issues.rb
@@ -32,7 +32,7 @@ module Jekyll
         filters[src] ||= HTML::Pipeline.new([
           HTML::Pipeline::HashtagFilter,
         ], { :tag_url => src,
-             :hashtag_pattern => /[^"]#([\p{L}\w\-]+)/ })
+             :hashtag_pattern => /gh#([\p{L}\w\-]+)/ })
       end
 
       # Public: Filters hash where the key is the mention base URL.

--- a/_plugins/github_issues.rb
+++ b/_plugins/github_issues.rb
@@ -31,7 +31,8 @@ module Jekyll
       def filter_with_mention(src)
         filters[src] ||= HTML::Pipeline.new([
           HTML::Pipeline::HashtagFilter,
-        ], { :tag_url => src })
+        ], { :tag_url => src,
+             :hashtag_pattern => /[^"]#([\p{L}\w\-]+)/ })
       end
 
       # Public: Filters hash where the key is the mention base URL.

--- a/_posts/2017-09-26-talking-tock-28.md
+++ b/_posts/2017-09-26-talking-tock-28.md
@@ -93,55 +93,55 @@ categories this time.
 
 #### Thread/6lowpan
 
-  * (#524) @bbbert implemented ieee802154 data frame encoding & decoding
-  * (#578) @bbbert implemented ieee802154 mac security
-  * (#589) @bbbert fixed the interrupt handling flow for the rf233 radio driver
-  * (#588) @mog96 implemented encoding and decoding for Thread's TLV mesh link establishment messages
-  * (#607) @bbbert virtualized the ieee802154 radio layer
+  * (gh#524) @bbbert implemented ieee802154 data frame encoding & decoding
+  * (gh#578) @bbbert implemented ieee802154 mac security
+  * (gh#589) @bbbert fixed the interrupt handling flow for the rf233 radio driver
+  * (gh#588) @mog96 implemented encoding and decoding for Thread's TLV mesh link establishment messages
+  * (gh#607) @bbbert virtualized the ieee802154 radio layer
 
 #### NRF5x Port
 
-  * (#583) @niklasad1 added error messages when using program option for nrf5x boards
-  * (#585) @niklasad1 refactored much of the nrf51 and nrf52 code into a common nrf5x crate
-  * (#615) @JayKickliter implemented a SPI master adaptation driver for the NRF52
+  * (gh#583) @niklasad1 added error messages when using program option for nrf5x boards
+  * (gh#585) @niklasad1 refactored much of the nrf51 and nrf52 code into a common nrf5x crate
+  * (gh#615) @JayKickliter implemented a SPI master adaptation driver for the NRF52
 
 #### Towards Tock 1.0
 
-  * (#560) @alevy changed the console driver to require a `command` to trigger a transaction
-  * (#573) @alevy added an ambient light sensor HIL
-  * (#586) @alevy Fix elf2tbf to use a dynamically generated text-region base address
-  * (#582) @niklasad1 implemented generic interfaces for humidity and temperature sensors
+  * (gh#560) @alevy changed the console driver to require a `command` to trigger a transaction
+  * (gh#573) @alevy added an ambient light sensor HIL
+  * (gh#586) @alevy Fix elf2tbf to use a dynamically generated text-region base address
+  * (gh#582) @niklasad1 implemented generic interfaces for humidity and temperature sensors
 
 #### Userland
 
-  * (#556) @bradjc made Bluetooth Low Energy environment sensing a userland service
-  * (#584) @shaneleonard created a unit testing framework for processes
+  * (gh#556) @bradjc made Bluetooth Low Energy environment sensing a userland service
+  * (gh#584) @shaneleonard created a unit testing framework for processes
 
 #### Administrativia
 
-  * (#568) @ppannuto made sure GCC version is checked in kernel build
-  * (#577) @alevy removed `imixv1` board from the tree
-  * (#569) @phil-levis added support for the kernel to allocate regions of flash memory for storage
-  * (#591) @ppannuto added some more comments to the Hail board
-  * (#606) @JayKickliter added automatic conversion of `process:Error` to `ReturnCode`
-  * (#609) @bradjc added a pull request template
-  * (#611) @ppannuto added a style section to the CONTRIBUTING document
-  * (#612) @bradjc added `and_then()` methods to `TakeCell` and `MapCell`
-  * (#620) @bradjc update us to a recent version of `rustc`
-  * (#624) @alevy renamed `Container` to `Grant` to match documentation and paper
+  * (gh#568) @ppannuto made sure GCC version is checked in kernel build
+  * (gh#577) @alevy removed `imixv1` board from the tree
+  * (gh#569) @phil-levis added support for the kernel to allocate regions of flash memory for storage
+  * (gh#591) @ppannuto added some more comments to the Hail board
+  * (gh#606) @JayKickliter added automatic conversion of `process:Error` to `ReturnCode`
+  * (gh#609) @bradjc added a pull request template
+  * (gh#611) @ppannuto added a style section to the CONTRIBUTING document
+  * (gh#612) @bradjc added `and_then()` methods to `TakeCell` and `MapCell`
+  * (gh#620) @bradjc update us to a recent version of `rustc`
+  * (gh#624) @alevy renamed `Container` to `Grant` to match documentation and paper
 
 ### Proposed
 
 #### Thread/6lowpan
 
-  * (#581) @ptcrews implemented 6lowpan fragmentation
+  * (gh#581) @ptcrews implemented 6lowpan fragmentation
 
 #### Towards Tock 1.0
 
-  * (#599) @alevy proposed a standardization of some system call interfaces for Tock 1.0
-  * (#623) @niklasad1 proposed a generic user-level interface for Bluetooth Low Energy
+  * (gh#599) @alevy proposed a standardization of some system call interfaces for Tock 1.0
+  * (gh#623) @niklasad1 proposed a generic user-level interface for Bluetooth Low Energy
 
 #### Administrativia
 
-  * (#614) @phil-levis proposed a generical virtualization layer for kernel interfaces
+  * (gh#614) @phil-levis proposed a generical virtualization layer for kernel interfaces
 


### PR DESCRIPTION
Prevent the tool from matching hashtags inside of quotes, like:

    "#88774a"

https://nogithubhack--tockosorg.netlify.com/hardware/

Should fix the issue with CSS colors getting linkified.